### PR TITLE
Remove duplicated value of length RIV

### DIFF
--- a/Test.c
+++ b/Test.c
@@ -48,9 +48,19 @@ Test(TestArguments, dci_ValidPositiveArguments)
 			{"0", "dci60a", "20"},
 	};
 
-	uint8_t dci_bitLengthArray_expected[] = {6, 15, 25, 50, 75, 100, 6, 15, 25, 50, 75, 100, 6, 15, 25, 50, 75, 100};
-	dciType dci_str_expected[] = {dci0, dci0, dci0, dci0, dci0, dci0, dci1, dci1, dci1,
-			dci1, dci1, dci1, dci60a, dci60a, dci60a, dci60a, dci60a, dci60a};
+	uint8_t dci_bitLengthArray_expected[] =
+	{
+			6, 15, 25, 50, 75, 100,
+			6, 15, 25, 50, 75, 100,
+			6, 15, 25, 50, 75, 100
+	};
+
+	dciType dci_str_expected[] =
+	{
+			dci0, dci0, dci0, dci0, dci0, dci0,
+			dci1, dci1, dci1, dci1, dci1, dci1,
+			dci60a, dci60a, dci60a, dci60a, dci60a, dci60a
+	};
 
 	uint32_t bandwidthPRB;
 	dciType dciResult;

--- a/dciCommon.c
+++ b/dciCommon.c
@@ -196,7 +196,8 @@ void dci0_CorrectnessParameters(uint8_t* dciParam, const uint8_t dci0_bandwidthP
 		errorCounter++;
 	}
 
-	if (dciParam[dci0_firstPRBOutput] > dciParam[dci0_lastPRBOutput] || dciParam[dci0_lastPRBOutput] >= dci0_bandwidthPRB)
+	if (dciParam[dci0_firstPRBOutput] > dciParam[dci0_lastPRBOutput] ||
+			dciParam[dci0_lastPRBOutput] >= dci0_bandwidthPRB)
 	{
 		DEBUG_PRINT("ERR_OCC_Inncorrect_value_of_PRB\n");
 		errorCounter++;
@@ -293,7 +294,8 @@ void dci60a_CorrectnessParameters(uint8_t* dciParam, const uint8_t dci60a_bandwi
 			for (size_t j = 0; j < dci60a_lenghtOfFirstPrbsArrays[i]; j++ )
 			{
 				if (!(dci60a_avaibleFirstPrbs[i][j] == dciParam[dci0_firstPRBOutput] &&
-						dci60a_avaibleFirstPrbs[i][j] + DCI60A_MAX_NUMBER_OF_ALLOCATED_RBS - 1 == dciParam[dci0_lastPRBOutput]))
+						dci60a_avaibleFirstPrbs[i][j] + DCI60A_MAX_NUMBER_OF_ALLOCATED_RBS - 1 ==
+								dciParam[dci0_lastPRBOutput]))
 				{
 					DEBUG_PRINT("ERR_OCC_FirstPRB_or_LastPRB_is_not_avaible_for_CAT-M_cells\n");
 					errorCounter++;

--- a/dciCommon.h
+++ b/dciCommon.h
@@ -9,7 +9,6 @@
 /* Shared Length of parameters */
 #define FORMAT_FLAG 1
 #define HOPPING_FLAG 1
-#define RIV 13
 #define CSIR 1
 #define SRSR 1
 #define NDI 1
@@ -20,10 +19,10 @@
 
 /* dci0 Length of parameters */
 #define DMRS 3
-#define RA 1
 #define DCI0_NUMBER_PARAM 9
 
 /* dci1 Length of parameters */
+#define RA 1
 #define DCI1_NUMBER_PARAM 7
 
 /* dci60a Length of parameters */
@@ -71,7 +70,7 @@ typedef enum dci1_OutputParameters
 	dci1_maxAmountOfArgumentsValue
 } dci1_OutputParameters;
 
-enum dci60a_InputParameters
+typedef enum dci60a_InputParameters
 {
 	dci60a_narrowbandIndex,
 	dci60a_rivLength,
@@ -87,7 +86,7 @@ enum dci60a_InputParameters
 	dci60a_maxAmmountOfArguments
 } dci60a_InputParameters;
 
-enum dci60a_OutputParameters
+typedef enum dci60a_OutputParameters
 {
 	dci60a_FirstPRBoutput,
 	dci60a_LastPRBoutput,


### PR DESCRIPTION
Refactor code in all of files to not overstep a one hundred characters in one line.
Changed enum to typedef enum in common.h to kept the same dependence between other enum's.